### PR TITLE
Correct process termination

### DIFF
--- a/src/nc_signal.c
+++ b/src/nc_signal.c
@@ -22,15 +22,16 @@
 #include <nc_signal.h>
 
 static struct signal signals[] = {
-    { SIGUSR1, "SIGUSR1", 0,                 signal_handler },
-    { SIGUSR2, "SIGUSR2", 0,                 signal_handler },
-    { SIGTTIN, "SIGTTIN", 0,                 signal_handler },
-    { SIGTTOU, "SIGTTOU", 0,                 signal_handler },
-    { SIGHUP,  "SIGHUP",  0,                 signal_handler },
-    { SIGINT,  "SIGINT",  0,                 signal_handler },
-    { SIGSEGV, "SIGSEGV", (int)SA_RESETHAND, signal_handler },
-    { SIGPIPE, "SIGPIPE", 0,                 SIG_IGN },
-    { 0,        NULL,     0,                 NULL }
+    { SIGUSR1, "SIGUSR1",  0,                 signal_handler },
+    { SIGUSR2, "SIGUSR2",  0,                 signal_handler },
+    { SIGTTIN, "SIGTTIN",  0,                 signal_handler },
+    { SIGTTOU, "SIGTTOU",  0,                 signal_handler },
+    { SIGHUP,  "SIGHUP",   0,                 signal_handler },
+    { SIGINT,  "SIGINT",   0,                 signal_handler },
+    { SIGTERM, "SIGTERM",  0,                 signal_handler },
+    { SIGSEGV, "SIGSEGV",  (int)SA_RESETHAND, signal_handler },
+    { SIGPIPE, "SIGPIPE",  0,                 SIG_IGN },
+    { 0,        NULL,      0,                 NULL }
 };
 
 rstatus_t
@@ -105,6 +106,7 @@ signal_handler(int signo)
         break;
 
     case SIGINT:
+    case SIGTERM:
         done = true;
         actionstr = ", exiting";
         break;
@@ -126,6 +128,6 @@ signal_handler(int signo)
     }
 
     if (done) {
-        exit(1);
+        exit(0);
     }
 }


### PR DESCRIPTION
Problem

1) If we run twemproxy on Kubernetes, `exit(1)` means that something goes wrong.
It breaks our alerting rule and have to silence if it is a twemproxy container.

2) We have to specify `STOPSIGNAL` in our configuration, 
since twemproxy only handle `SIGINT` to terminate the process.

Solution

1) Change exit code to 0 to terminate correctly.

2) Add `SIGTERM` into signal_handler to recognize `TERM` signal.

Result

1) No misdetection happens on terminating twemproxy.
2) No need to set `STOPSIGNAL` config in our manifest.

