### PR TITLE
Abort connection on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ Twemproxy can be configured through a YAML file specified by the -c or --conf-fi
  + modula
  + random
 + **timeout**: The timeout value in msec that we wait for to establish a connection to the server or receive a response from a server. By default, we wait indefinitely.
++ **abort_on_timeout**: A boolean value that controls if twemproxy abort a connection on timeout(ETIMEDOUT). Defaults to false.  
++ **abort_on_refused**: A boolean value that controls if twemproxy abort a connection on connection refused(ECONNREFUSED). Defaults to false.
++ **abort_on_invalid**: A boolean value that controls if twemproxy abort a connection on invalid argument(EINVAL). Defaults to false.
 + **backlog**: The TCP backlog argument. Defaults to 512.
 + **preconnect**: A boolean value that controls if twemproxy should preconnect to all the servers in this pool on process start. Defaults to false.
 + **redis**: A boolean value that controls if a server pool speaks redis or memcached protocol. Defaults to false.

--- a/src/nc_conf.c
+++ b/src/nc_conf.c
@@ -62,6 +62,18 @@ static struct command conf_commands[] = {
       conf_set_num,
       offsetof(struct conf_pool, timeout) },
 
+    { string("abort_on_timeout"),
+      conf_set_bool,
+      offsetof(struct conf_pool, abort_on_timeout) },
+
+    { string("abort_on_refused"),
+      conf_set_bool,
+      offsetof(struct conf_pool, abort_on_refused) },
+
+    { string("abort_on_invalid"),
+      conf_set_bool,
+      offsetof(struct conf_pool, abort_on_invalid) },
+
     { string("backlog"),
       conf_set_num,
       offsetof(struct conf_pool, backlog) },
@@ -193,6 +205,9 @@ conf_pool_init(struct conf_pool *cp, struct string *name)
     cp->distribution = CONF_UNSET_DIST;
 
     cp->timeout = CONF_UNSET_NUM;
+    cp->abort_on_timeout = CONF_UNSET_NUM;
+    cp->abort_on_refused = CONF_UNSET_NUM;
+    cp->abort_on_invalid = CONF_UNSET_NUM;
     cp->backlog = CONF_UNSET_NUM;
 
     cp->client_connections = CONF_UNSET_NUM;
@@ -290,6 +305,9 @@ conf_pool_each_transform(void *elem, void *data)
 
     sp->redis = cp->redis ? 1 : 0;
     sp->timeout = cp->timeout;
+    sp->abort_on_timeout = cp->abort_on_timeout;
+    sp->abort_on_refused = cp->abort_on_refused;
+    sp->abort_on_invalid = cp->abort_on_invalid;
     sp->backlog = cp->backlog;
     sp->redis_db = cp->redis_db;
 
@@ -336,6 +354,9 @@ conf_dump(struct conf *cf)
         log_debug(LOG_VVERB, "  listen: %.*s",
                   cp->listen.pname.len, cp->listen.pname.data);
         log_debug(LOG_VVERB, "  timeout: %d", cp->timeout);
+        log_debug(LOG_VVERB, "  abort_on_timeout: %d", cp->abort_on_timeout);
+        log_debug(LOG_VVERB, "  abort_on_refused: %d", cp->abort_on_refused);
+        log_debug(LOG_VVERB, "  abort_on_invalid: %d", cp->abort_on_invalid);
         log_debug(LOG_VVERB, "  backlog: %d", cp->backlog);
         log_debug(LOG_VVERB, "  hash: %d", cp->hash);
         log_debug(LOG_VVERB, "  hash_tag: \"%.*s\"", cp->hash_tag.len,
@@ -1226,6 +1247,18 @@ conf_validate_pool(struct conf *cf, struct conf_pool *cp)
 
     if (cp->timeout == CONF_UNSET_NUM) {
         cp->timeout = CONF_DEFAULT_TIMEOUT;
+    }
+
+    if (cp->abort_on_timeout == CONF_UNSET_NUM) {
+        cp->abort_on_timeout = CONF_DEFAULT_ABORT_ON_TIMEOUT;
+    }
+
+    if (cp->abort_on_refused == CONF_UNSET_NUM) {
+        cp->abort_on_refused = CONF_DEFAULT_ABORT_ON_REFUSED;
+    }
+
+    if (cp->abort_on_invalid == CONF_UNSET_NUM) {
+        cp->abort_on_invalid = CONF_DEFAULT_ABORT_ON_INVALID;
     }
 
     if (cp->backlog == CONF_UNSET_NUM) {

--- a/src/nc_conf.h
+++ b/src/nc_conf.h
@@ -44,6 +44,9 @@
 #define CONF_DEFAULT_HASH                    HASH_FNV1A_64
 #define CONF_DEFAULT_DIST                    DIST_KETAMA
 #define CONF_DEFAULT_TIMEOUT                 -1
+#define CONF_DEFAULT_ABORT_ON_TIMEOUT        false
+#define CONF_DEFAULT_ABORT_ON_REFUSED        false
+#define CONF_DEFAULT_ABORT_ON_INVALID        false
 #define CONF_DEFAULT_LISTEN_BACKLOG          512
 #define CONF_DEFAULT_CLIENT_CONNECTIONS      0
 #define CONF_DEFAULT_REDIS                   false
@@ -82,6 +85,9 @@ struct conf_pool {
     struct string      hash_tag;              /* hash_tag: */
     dist_type_t        distribution;          /* distribution: */
     int                timeout;               /* timeout: */
+    int                abort_on_timeout;      /* send RST back to client on timeout? */
+    int                abort_on_refused;      /* send RST back to client on refused? */
+    int                abort_on_invalid;      /* send RST back to client on invalid? */
     int                backlog;               /* backlog: */
     int                client_connections;    /* client_connections: */
     int                tcpkeepalive;          /* tcpkeepalive: */

--- a/src/nc_request.c
+++ b/src/nc_request.c
@@ -528,6 +528,23 @@ req_forward_error(struct context *ctx, struct conn *conn, struct msg *msg)
     msg->done = 1;
     msg->error = 1;
     msg->err = errno;
+    switch(msg->err) {
+        case EPIPE:
+        case ECONNRESET:
+        case ECONNABORTED:
+        case ENOTCONN:
+        case ENETDOWN:
+        case ENETUNREACH:
+        case EHOSTDOWN:
+        case EHOSTUNREACH:
+        case ETIMEDOUT:
+        case ECONNREFUSED:
+        case EINVAL:
+            conn->err = msg->err;
+            break;
+        default:
+            break;
+    }
 
     /* noreply request don't expect any response */
     if (msg->noreply) {

--- a/src/nc_server.h
+++ b/src/nc_server.h
@@ -121,6 +121,9 @@ struct server_pool {
     unsigned           preconnect:1;         /* preconnect? */
     unsigned           redis:1;              /* redis? */
     unsigned           tcpkeepalive:1;       /* tcpkeepalive? */
+    unsigned           abort_on_timeout:1;   /* send RST back to client on timeout? */
+    unsigned           abort_on_refused:1;   /* send RST back to client on refused? */
+    unsigned           abort_on_invalid:1;   /* send RST back to client on invalid? */
 };
 
 void server_ref(struct conn *conn, void *owner);


### PR DESCRIPTION
Problem

If the backend server of twemproxy down, twemproxy sends an error message like -ERR Host is down.
However, some of the client library ( in our case phpredis ) cannot recognize it as an error but ignores it.

Solution

If the error occurred on the backend of twemproxy, twemproxy sends RST packet back to the client,
so that the client can raise an exception correctly.

Result

The client library (phpredis) now throws an exception when redis, which is our backend of twemproxy, is down.