### PR TITLE
add redis_db in monitor output

### DIFF
--- a/src/nc_stats.c
+++ b/src/nc_stats.c
@@ -327,6 +327,27 @@ stats_pool_unmap(struct array *stats_pool)
 }
 
 static rstatus_t
+stats_pool_redis_db_init(struct array *stats_pool, struct array *server_pool)
+{
+    uint32_t i, npool;
+
+    npool = array_n(server_pool);
+    ASSERT(npool != 0);
+
+    for (i = 0; i < npool; i++) {
+        struct server_pool *sp = array_get(server_pool, i);
+        struct stats_pool *stp = array_get(stats_pool, i);
+        struct stats_metric *stm;
+
+        // init redis_db in metrics
+        stm = array_get(&stp->metric, STATS_POOL_redis_db);
+        stm->value.counter = (int64_t)sp->redis_db;
+    }
+
+    return NC_OK;
+}
+
+static rstatus_t
 stats_create_buf(struct stats *st)
 {
     uint32_t int64_max_digits = 20; /* INT64_MAX = 9223372036854775807 */
@@ -936,6 +957,11 @@ stats_create(uint16_t stats_port, char *stats_ip, int stats_interval,
     /* map server pool to current (a), shadow (b) and sum (c) */
 
     status = stats_pool_map(&st->current, server_pool);
+    if (status != NC_OK) {
+        goto error;
+    }
+
+    status = stats_pool_redis_db_init(&st->current, server_pool);
     if (status != NC_OK) {
         goto error;
     }

--- a/src/nc_stats.h
+++ b/src/nc_stats.h
@@ -22,6 +22,7 @@
 
 #define STATS_POOL_CODEC(ACTION)                                                                                    \
     /* client behavior */                                                                                           \
+    ACTION( redis_db,               STATS_GAUGE,        "# redis database number")                                  \
     ACTION( client_eof,             STATS_COUNTER,      "# eof on client connections")                              \
     ACTION( client_err,             STATS_COUNTER,      "# errors on client connections")                           \
     ACTION( client_connections,     STATS_GAUGE,        "# active client connections")                              \

--- a/tests/lib/server_modules.py
+++ b/tests/lib/server_modules.py
@@ -214,7 +214,7 @@ class Memcached(Base):
 
 class NutCracker(Base):
     def __init__(self, host, port, path, cluster_name, masters, mbuf=512,
-            verbose=5, is_redis=True, redis_auth=None):
+            verbose=5, is_redis=True, redis_auth=None, redis_db=0):
         Base.__init__(self, 'nutcracker', host, port, path)
 
         self.masters = masters
@@ -233,8 +233,9 @@ class NutCracker(Base):
         self.args['runcmd']   = TTCMD('bin/nutcracker -d -c $conf -o $logfile \
                                        -p $pidfile -s $status_port', self.args)
 
-        self.args['cluster_name']= cluster_name
-        self.args['is_redis']= str(is_redis).lower()
+        self.args['cluster_name' ]= cluster_name
+        self.args['is_redis'] = str(is_redis).lower()
+        self.args['redis_db'] = redis_db
 
     def _alive(self):
         return self._info_dict()
@@ -248,6 +249,7 @@ class NutCracker(Base):
         content = '''
 $cluster_name:
   listen: 0.0.0.0:$port
+  redis_db: $redis_db
   hash: fnv1a_64
   distribution: modula
   preconnect: true

--- a/tests/test_redis/test_basic.py
+++ b/tests/test_redis/test_basic.py
@@ -101,7 +101,7 @@ def test_nc_stats():
         stat = nc._info_dict()
         #pprint(stat)
         if name in ['client_connections', 'client_eof', 'client_err', \
-                    'forward_error', 'fragments', 'server_ejects']:
+                    'forward_error', 'fragments', 'server_ejects', 'redis_db']:
             return stat[CLUSTER_NAME][name]
 
         #sum num of each server
@@ -125,6 +125,21 @@ def test_nc_stats():
     #for mget-improve
     assert(get_stat('requests') == 22)
     assert(get_stat('responses') == 22)
+
+    # redis_db test
+    assert(get_stat('redis_db') == 0)
+
+    nc.args['redis_db'] = 3
+    nc.stop()
+    nc.deploy()
+    nc.start()
+    assert(get_stat('redis_db') == 3)
+
+    nc.args['redis_db'] = 0
+    nc.stop()
+    nc.deploy()
+    nc.start()
+    assert(get_stat('redis_db') == 0)
 
 def test_issue_323():
     # do on redis


### PR DESCRIPTION
一旦実装はしたんですが、細かいところはこれから

config
```
alpha:
  listen: 127.0.0.1:22121
  hash: fnv1a_64
  distribution: ketama
  auto_eject_hosts: true
  redis: true
  server_retry_timeout: 2000
  server_failure_limit: 1
  servers:
   - 127.0.0.1:6379:1

beta:
  listen: 127.0.0.1:22122
  redis_db: 1
  hash: fnv1a_64
  hash_tag: "{}"
  distribution: ketama
  auto_eject_hosts: false
  timeout: 400
  redis: true
  servers:
   - 127.0.0.1:6380:1 server1
   - 127.0.0.1:6381:1 server2
   - 127.0.0.1:6382:1 server3
   - 127.0.0.1:6383:1 server4

gamma:
  listen: 127.0.0.1:22123
  redis_db: 2
  hash: fnv1a_64
  distribution: ketama
  timeout: 400
  backlog: 1024
  preconnect: true
  auto_eject_hosts: true
  server_retry_timeout: 2000
  server_failure_limit: 3
  servers:
   - 127.0.0.1:11212:1
   - 127.0.0.1:11213:1

delta:
  listen: 127.0.0.1:22124
  redis_db: 3
  hash: fnv1a_64
  distribution: ketama
  timeout: 100
  auto_eject_hosts: true
  server_retry_timeout: 2000
  server_failure_limit: 1
  servers:
   - 127.0.0.1:11214:1
   - 127.0.0.1:11215:1
   - 127.0.0.1:11216:1
   - 127.0.0.1:11217:1
   - 127.0.0.1:11218:1
   - 127.0.0.1:11219:1
   - 127.0.0.1:11220:1
   - 127.0.0.1:11221:1
   - 127.0.0.1:11222:1
   - 127.0.0.1:11223:1

omega:
  listen: /tmp/gamma 0666
  redis_db: 4
  hash: hsieh
  distribution: ketama
  auto_eject_hosts: false
  servers:
   - 127.0.0.1:11214:100000
   - 127.0.0.1:11215:1
```

monitor output
```
{
  "service": "nutcracker",
  "source": "af0b8c1184fa",
  "version": "0.4.1",
  "uptime": 4,
  "timestamp": 1605094944,
  "total_connections": 7,
  "curr_connections": 5,
  "beta": {
    "redis_db": 1,
    "client_eof": 0,
    "client_err": 0,
    "client_connections": 0,
    "server_ejects": 0,
    "forward_error": 0,
    "fragments": 0,
    "server1": {
      "server_eof": 0,
      "server_err": 0,
      "server_timedout": 0,
      "server_connections": 0,
      "server_ejected_at": 0,
      "requests": 0,
      "request_bytes": 0,
      "responses": 0,
      "response_bytes": 0,
      "in_queue": 0,
      "in_queue_bytes": 0,
      "out_queue": 0,
      "out_queue_bytes": 0
    },
    "server2": {
      "server_eof": 0,
      "server_err": 0,
      "server_timedout": 0,
      "server_connections": 0,
      "server_ejected_at": 0,
      "requests": 0,
      "request_bytes": 0,
      "responses": 0,
      "response_bytes": 0,
      "in_queue": 0,
      "in_queue_bytes": 0,
      "out_queue": 0,
      "out_queue_bytes": 0
    },
    "server3": {
      "server_eof": 0,
      "server_err": 0,
      "server_timedout": 0,
      "server_connections": 0,
      "server_ejected_at": 0,
      "requests": 0,
      "request_bytes": 0,
      "responses": 0,
      "response_bytes": 0,
      "in_queue": 0,
      "in_queue_bytes": 0,
      "out_queue": 0,
      "out_queue_bytes": 0
    },
    "server4": {
      "server_eof": 0,
      "server_err": 0,
      "server_timedout": 0,
      "server_connections": 0,
      "server_ejected_at": 0,
      "requests": 0,
      "request_bytes": 0,
      "responses": 0,
      "response_bytes": 0,
      "in_queue": 0,
      "in_queue_bytes": 0,
      "out_queue": 0,
      "out_queue_bytes": 0
    }
  },
  "alpha": {
    "redis_db": 0,
    "client_eof": 0,
    "client_err": 0,
    "client_connections": 0,
    "server_ejects": 0,
    "forward_error": 0,
    "fragments": 0,
    "127.0.0.1:6379": {
      "server_eof": 0,
      "server_err": 0,
      "server_timedout": 0,
      "server_connections": 0,
      "server_ejected_at": 0,
      "requests": 0,
      "request_bytes": 0,
      "responses": 0,
      "response_bytes": 0,
      "in_queue": 0,
      "in_queue_bytes": 0,
      "out_queue": 0,
      "out_queue_bytes": 0
    }
  },
  "delta": {
    "redis_db": 3,
    "client_eof": 0,
    "client_err": 0,
    "client_connections": 0,
    "server_ejects": 0,
    "forward_error": 0,
    "fragments": 0,
    "127.0.0.1:11214": {
      "server_eof": 0,
      "server_err": 0,
      "server_timedout": 0,
      "server_connections": 0,
      "server_ejected_at": 0,
      "requests": 0,
      "request_bytes": 0,
      "responses": 0,
      "response_bytes": 0,
      "in_queue": 0,
      "in_queue_bytes": 0,
      "out_queue": 0,
      "out_queue_bytes": 0
    },
    "127.0.0.1:11215": {
      "server_eof": 0,
      "server_err": 0,
      "server_timedout": 0,
      "server_connections": 0,
      "server_ejected_at": 0,
      "requests": 0,
      "request_bytes": 0,
      "responses": 0,
      "response_bytes": 0,
      "in_queue": 0,
      "in_queue_bytes": 0,
      "out_queue": 0,
      "out_queue_bytes": 0
    },
    "127.0.0.1:11216": {
      "server_eof": 0,
      "server_err": 0,
      "server_timedout": 0,
      "server_connections": 0,
      "server_ejected_at": 0,
      "requests": 0,
      "request_bytes": 0,
      "responses": 0,
      "response_bytes": 0,
      "in_queue": 0,
      "in_queue_bytes": 0,
      "out_queue": 0,
      "out_queue_bytes": 0
    },
    "127.0.0.1:11217": {
      "server_eof": 0,
      "server_err": 0,
      "server_timedout": 0,
      "server_connections": 0,
      "server_ejected_at": 0,
      "requests": 0,
      "request_bytes": 0,
      "responses": 0,
      "response_bytes": 0,
      "in_queue": 0,
      "in_queue_bytes": 0,
      "out_queue": 0,
      "out_queue_bytes": 0
    },
    "127.0.0.1:11218": {
      "server_eof": 0,
      "server_err": 0,
      "server_timedout": 0,
      "server_connections": 0,
      "server_ejected_at": 0,
      "requests": 0,
      "request_bytes": 0,
      "responses": 0,
      "response_bytes": 0,
      "in_queue": 0,
      "in_queue_bytes": 0,
      "out_queue": 0,
      "out_queue_bytes": 0
    },
    "127.0.0.1:11219": {
      "server_eof": 0,
      "server_err": 0,
      "server_timedout": 0,
      "server_connections": 0,
      "server_ejected_at": 0,
      "requests": 0,
      "request_bytes": 0,
      "responses": 0,
      "response_bytes": 0,
      "in_queue": 0,
      "in_queue_bytes": 0,
      "out_queue": 0,
      "out_queue_bytes": 0
    },
    "127.0.0.1:11220": {
      "server_eof": 0,
      "server_err": 0,
      "server_timedout": 0,
      "server_connections": 0,
      "server_ejected_at": 0,
      "requests": 0,
      "request_bytes": 0,
      "responses": 0,
      "response_bytes": 0,
      "in_queue": 0,
      "in_queue_bytes": 0,
      "out_queue": 0,
      "out_queue_bytes": 0
    },
    "127.0.0.1:11221": {
      "server_eof": 0,
      "server_err": 0,
      "server_timedout": 0,
      "server_connections": 0,
      "server_ejected_at": 0,
      "requests": 0,
      "request_bytes": 0,
      "responses": 0,
      "response_bytes": 0,
      "in_queue": 0,
      "in_queue_bytes": 0,
      "out_queue": 0,
      "out_queue_bytes": 0
    },
    "127.0.0.1:11222": {
      "server_eof": 0,
      "server_err": 0,
      "server_timedout": 0,
      "server_connections": 0,
      "server_ejected_at": 0,
      "requests": 0,
      "request_bytes": 0,
      "responses": 0,
      "response_bytes": 0,
      "in_queue": 0,
      "in_queue_bytes": 0,
      "out_queue": 0,
      "out_queue_bytes": 0
    },
    "127.0.0.1:11223": {
      "server_eof": 0,
      "server_err": 0,
      "server_timedout": 0,
      "server_connections": 0,
      "server_ejected_at": 0,
      "requests": 0,
      "request_bytes": 0,
      "responses": 0,
      "response_bytes": 0,
      "in_queue": 0,
      "in_queue_bytes": 0,
      "out_queue": 0,
      "out_queue_bytes": 0
    }
  },
  "gamma": {
    "redis_db": 2,
    "client_eof": 0,
    "client_err": 0,
    "client_connections": 0,
    "server_ejects": 0,
    "forward_error": 0,
    "fragments": 0,
    "127.0.0.1:11212": {
      "server_eof": 0,
      "server_err": 1,
      "server_timedout": 0,
      "server_connections": 0,
      "server_ejected_at": 0,
      "requests": 0,
      "request_bytes": 0,
      "responses": 0,
      "response_bytes": 0,
      "in_queue": 0,
      "in_queue_bytes": 0,
      "out_queue": 0,
      "out_queue_bytes": 0
    },
    "127.0.0.1:11213": {
      "server_eof": 0,
      "server_err": 1,
      "server_timedout": 0,
      "server_connections": 0,
      "server_ejected_at": 0,
      "requests": 0,
      "request_bytes": 0,
      "responses": 0,
      "response_bytes": 0,
      "in_queue": 0,
      "in_queue_bytes": 0,
      "out_queue": 0,
      "out_queue_bytes": 0
    }
  },
  "omega": {
    "redis_db": 4,
    "client_eof": 0,
    "client_err": 0,
    "client_connections": 0,
    "server_ejects": 0,
    "forward_error": 0,
    "fragments": 0,
    "127.0.0.1:11214": {
      "server_eof": 0,
      "server_err": 0,
      "server_timedout": 0,
      "server_connections": 0,
      "server_ejected_at": 0,
      "requests": 0,
      "request_bytes": 0,
      "responses": 0,
      "response_bytes": 0,
      "in_queue": 0,
      "in_queue_bytes": 0,
      "out_queue": 0,
      "out_queue_bytes": 0
    },
    "127.0.0.1:11215": {
      "server_eof": 0,
      "server_err": 0,
      "server_timedout": 0,
      "server_connections": 0,
      "server_ejected_at": 0,
      "requests": 0,
      "request_bytes": 0,
      "responses": 0,
      "response_bytes": 0,
      "in_queue": 0,
      "in_queue_bytes": 0,
      "out_queue": 0,
      "out_queue_bytes": 0
    }
  }
}
```