### PR TITLE
Support geo commands and to parse nested multi bulk reply

### DIFF
--- a/src/nc_message.c
+++ b/src/nc_message.c
@@ -255,6 +255,7 @@ done:
     msg->narg_end = NULL;
     msg->narg = 0;
     msg->rnarg = 0;
+    msg->depth = 0;
     msg->rlen = 0;
     msg->integer = 0;
 

--- a/src/nc_message.h
+++ b/src/nc_message.h
@@ -34,6 +34,8 @@ typedef enum msg_parse_result {
     MSG_PARSE_AGAIN,                      /* incomplete -> parse again */
 } msg_parse_result_t;
 
+#define NC_MULTIBULK_MAX_DEPTH  3
+
 #define MSG_TYPE_CODEC(ACTION)                                                                      \
     ACTION( UNKNOWN )                                                                               \
     ACTION( REQ_MC_GET )                       /* memcache retrieval requests */                    \
@@ -161,11 +163,17 @@ typedef enum msg_parse_result {
     ACTION( REQ_REDIS_ZSCORE )                                                                      \
     ACTION( REQ_REDIS_ZUNIONSTORE )                                                                 \
     ACTION( REQ_REDIS_ZSCAN)                                                                        \
+    ACTION( REQ_REDIS_GEOADD )                 /* redis requests - geo */                           \
+    ACTION( REQ_REDIS_GEOPOS )                                                                      \
+    ACTION( REQ_REDIS_GEODIST )                                                                     \
+    ACTION( REQ_REDIS_GEOHASH )                                                                     \
+    ACTION( REQ_REDIS_GEORADIUS )                                                                   \
+    ACTION( REQ_REDIS_GEORADIUSBYMEMBER )                                                           \
     ACTION( REQ_REDIS_EVAL )                   /* redis requests - eval */                          \
     ACTION( REQ_REDIS_EVALSHA )                                                                     \
     ACTION( REQ_REDIS_PING )                   /* redis requests - ping/quit */                     \
-    ACTION( REQ_REDIS_QUIT)                                                                         \
-    ACTION( REQ_REDIS_AUTH)                                                                         \
+    ACTION( REQ_REDIS_QUIT )                                                                        \
+    ACTION( REQ_REDIS_AUTH )                                                                        \
     ACTION( REQ_REDIS_SELECT)                  /* only during init */                               \
     ACTION( RSP_REDIS_STATUS )                 /* redis response */                                 \
     ACTION( RSP_REDIS_ERROR )                                                                       \
@@ -214,6 +222,7 @@ struct msg {
     uint32_t             mlen;            /* message length */
     int64_t              start_ts;        /* request start timestamp in usec */
 
+    int                  depth;
     int                  state;           /* current parser state */
     uint8_t              *pos;            /* parser position marker */
     uint8_t              *token;          /* token marker */
@@ -240,6 +249,7 @@ struct msg {
     uint8_t              *narg_end;       /* narg end (redis) */
     uint32_t             narg;            /* # arguments (redis) */
     uint32_t             rnarg;           /* running # arg used by parsing fsa (redis) */
+    uint32_t             rnargs[NC_MULTIBULK_MAX_DEPTH];    /* running # arg used by parsing fsa (redis) */
     uint32_t             rlen;            /* running length in parsing fsa (redis) */
     uint32_t             integer;         /* integer reply value (redis) */
 

--- a/src/proto/nc_proto.h
+++ b/src/proto/nc_proto.h
@@ -138,6 +138,10 @@
     (str15icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14) &&       \
      (m[15] == c15 || m[15] == (c15 ^ 0x20)))
 
+#define str17icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16)  \
+    (str16icmp(m, c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15) &&       \
+     (m[16] == c16 || m[16] == (c16 ^ 0x20)))
+
 void memcache_parse_req(struct msg *r);
 void memcache_parse_rsp(struct msg *r);
 bool memcache_failure(struct msg *r);

--- a/src/proto/nc_redis.c
+++ b/src/proto/nc_redis.c
@@ -214,6 +214,12 @@ redis_argn(struct msg *r)
 
     case MSG_REQ_REDIS_BITCOUNT:
     case MSG_REQ_REDIS_BITPOS:
+    case MSG_REQ_REDIS_GEOADD:
+    case MSG_REQ_REDIS_GEOPOS:
+    case MSG_REQ_REDIS_GEODIST:
+    case MSG_REQ_REDIS_GEOHASH:
+    case MSG_REQ_REDIS_GEORADIUS:
+    case MSG_REQ_REDIS_GEORADIUSBYMEMBER:
 
     case MSG_REQ_REDIS_SET:
     case MSG_REQ_REDIS_HDEL:
@@ -809,6 +815,16 @@ redis_parse_req(struct msg *r)
                     break;
                 }
 
+                if (str6icmp(m, 'g', 'e', 'o', 'a', 'd', 'd')) {
+                    r->type = MSG_REQ_REDIS_GEOADD;
+                    break;
+                }
+
+                if (str6icmp(m, 'g', 'e', 'o', 'p', 'o', 's')) {
+                    r->type = MSG_REQ_REDIS_GEOPOS;
+                    break;
+                }
+
                 if (str6icmp(m, 'p', 's', 'e', 't', 'e', 'x')) {
                     r->type = MSG_REQ_REDIS_PSETEX;
                     break;
@@ -912,6 +928,16 @@ redis_parse_req(struct msg *r)
                     break;
                 }
 
+                if (str7icmp(m, 'g', 'e', 'o', 'd', 'i', 's', 't')) {
+                    r->type = MSG_REQ_REDIS_GEODIST;
+                    break;
+                }
+
+                if (str7icmp(m, 'g', 'e', 'o', 'h', 'a', 's', 'h')) {
+                    r->type = MSG_REQ_REDIS_GEOHASH;
+                    break;
+                }
+
                 if (str7icmp(m, 'z', 'i', 'n', 'c', 'r', 'b', 'y')) {
                     r->type = MSG_REQ_REDIS_ZINCRBY;
                     break;
@@ -973,6 +999,11 @@ redis_parse_req(struct msg *r)
                 break;
 
             case 9:
+                if (str9icmp(m, 'g', 'e', 'o', 'r', 'a', 'd', 'i', 'u', 's')) {
+                    r->type = MSG_REQ_REDIS_GEORADIUS;
+                    break;
+                }
+
                 if (str9icmp(m, 'p', 'e', 'x', 'p', 'i', 'r', 'e', 'a', 't')) {
                     r->type = MSG_REQ_REDIS_PEXPIREAT;
                     break;
@@ -1089,6 +1120,12 @@ redis_parse_req(struct msg *r)
                 }
 
                 break;
+
+            case 17:
+                if (str17icmp(m, 'g', 'e', 'o', 'r', 'a', 'd', 'i', 'u', 's', 'b', 'y', 'm', 'e', 'm', 'b', 'e', 'r')) {
+                    r->type = MSG_REQ_REDIS_GEORADIUSBYMEMBER;
+                    break;
+                }
 
             default:
                 break;
@@ -1687,6 +1724,25 @@ error:
 }
 
 /*
+ * Return true, if there are no remaining args to be parsed, otherwise
+ * return false
+ */
+static bool
+redis_decrement_depth_and_is_parse_done(struct msg *r) {
+    bool ret = false;
+    while (r->rnarg == 0 && r->depth > 0) {
+        r->depth--;
+        r->rnarg = r->rnargs[r->depth] - 1;
+    }
+
+    if (r->rnarg == 0 && r->depth == 0) {
+        ret = true;
+    }
+
+    return ret;
+}
+
+/*
  * Reference: http://redis.io/topics/protocol
  *
  * Redis will reply to commands with different kinds of replies. It is
@@ -2034,7 +2090,13 @@ redis_parse_rsp(struct msg *r)
         case SW_BULK_ARG_LF:
             switch (ch) {
             case LF:
-                goto done;
+                if (r->depth > 0) {
+                    if (redis_decrement_depth_and_is_parse_done(r)) {
+                        goto done;
+                    }
+                } else {
+                    goto done;
+                }
 
             default:
                 goto error;
@@ -2060,7 +2122,10 @@ redis_parse_rsp(struct msg *r)
                     goto error;
                 }
 
-                r->narg = r->rnarg;
+                if (r->depth == 0) {
+                    r->narg = r->rnarg;
+                }
+
                 r->narg_end = p;
                 r->token = NULL;
                 state = SW_MULTIBULK_NARG_LF;
@@ -2075,7 +2140,13 @@ redis_parse_rsp(struct msg *r)
             case LF:
                 if (r->rnarg == 0) {
                     /* response is '*0\r\n' */
-                    goto done;
+                    if (r->depth > 0) {
+                        if (redis_decrement_depth_and_is_parse_done(r)) {
+                            goto error;
+                        }
+                    } else {
+                        goto done;
+                    }
                 }
 
                 state = SW_MULTIBULK_ARGN_LEN;
@@ -2095,26 +2166,51 @@ redis_parse_rsp(struct msg *r)
                  * of a multi bulk reply can be of any kind, including a
                  * nested multi bulk reply.
                  *
-                 * Here, we only handle a multi bulk reply element that
+                 * Here, we can handle NC_MULTIBULK_MAX_DEPTH depth multi bulk reply element that
                  * are either integer reply or bulk reply.
                  *
-                 * there is a special case for sscan/hscan/zscan, these command
+                 * there is a special case for sscan/hscan/zscan/geopos/georadius/georadiusbymember, these command
                  * replay a nested multi-bulk with a number and a multi bulk like this:
                  *
-                 * - mulit-bulk
+                 * - multi-bulk
                  *    - cursor
-                 *    - mulit-bulk
+                 *    - multi-bulk
                  *       - val1
                  *       - val2
                  *       - val3
                  *
-                 * in this case, there is only one sub-multi-bulk,
-                 * and it's the last element of parent,
-                 * we can handle it like tail-recursive.
+                 * - multi-bulk
+                 *    - multi-bulk
+                 *       - val1
+                 *       - val2
+                 *       - val3
+                 *    - multi-bulk
+                 *       - val1
+                 *       - val2
+                 *       - val3
                  *
+                 * - multi-bulk
+                 *    - multi-bulk
+                 *       - val1
+                 *       - multi-bulk
+                 *          - val2
+                 *          - val3
+                 *    - multi-bulk
+                 *       - val1
+                 *       - multi-bulk
+                 *          - val2
+                 *          - val3
                  */
-                if (ch == '*') {    /* for sscan/hscan/zscan only */
+                if (ch == '*') {    /* for sscan/hscan/zscan/geopos/georadius/georadiusbymember only */
                     p = p - 1;      /* go back by 1 byte */
+
+                    if (r->depth >= NC_MULTIBULK_MAX_DEPTH) {
+                        goto error;
+                    }
+
+                    r->rnargs[r->depth] = r->rnarg;
+                    r->depth++;
+
                     state = SW_MULTIBULK;
                     break;
                 }
@@ -2191,7 +2287,13 @@ redis_parse_rsp(struct msg *r)
             switch (ch) {
             case LF:
                 if (r->rnarg == 0) {
-                    goto done;
+                    if (r->depth > 0) {
+                        if (redis_decrement_depth_and_is_parse_done(r)) {
+                            goto done;
+                        }
+                    } else {
+                        goto done;
+                    }
                 }
 
                 state = SW_MULTIBULK_ARGN_LEN;

--- a/tests/test_redis/test_geo_commands.py
+++ b/tests/test_redis/test_geo_commands.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python
+#coding: utf-8
+
+from .common import *
+
+def _geoadd_common(r):
+    return r.geoadd('Sicily',
+        13.361389, 38.115556, 'Palermo',
+        15.087269,  37.502669 , 'Catania'
+    )
+
+def test_geoadd():
+    r = getconn()
+
+    assert(_geoadd_common(r) == 2)
+
+    assert(r.geoadd('Sicily',
+        13.583333, 37.316667, 'Agrigento') == 1)
+
+    # reply is not changed count but added count
+    assert(_geoadd_common(r) == 0)
+
+    assert_fail('value is not a valid float', r.geoadd, 'key', 'invalidValue', 'invalidValue', 'invalidValue');
+
+    assert_fail('invalid longitude,latitude pair', r.geoadd, 'key', 0.0, -85.05112879, 'tooLowLat')
+
+    assert_fail('invalid longitude,latitude pair', r.geoadd, 'key', 0.0, 85.05112879, 'tooHighLat')
+
+    assert_fail('invalid longitude,latitude pair', r.geoadd, 'key', -180.00000001, 0.0, 'tooLowLng')
+
+    assert_fail('invalid longitude,latitude pair', r.geoadd, 'key', 180.00000001, 0.0, 'tooHighLng')
+
+
+def test_geodist():
+    r = getconn()
+
+    _geoadd_common(r)
+
+    assert(r.geodist('Sicily', 'Palermo' , 'Catania') == 166274.1516)
+
+    assert(r.geodist('Sicily', 'Palermo' , 'Catania', 'km') == 166.2742)
+
+    assert(r.geodist('Sicily', 'Palermo' , 'Catania', 'mi') == 103.3182)
+
+    assert(r.geodist('keyNotExists', 'memberNotExists1', 'memberNotExists2') == None)
+
+    assert(r.geodist('Sicily', 'memberNotExists1', 'memberNotExists2') == None)
+
+
+def test_geohash():
+    r = getconn()
+
+    _geoadd_common(r)
+
+    assert(r.geohash('Sicily', 'Palermo' , 'Catania') == ['sqc8b49rny0', 'sqdtr74hyu0'])
+
+    assert(r.geohash('keyNotExists', 'memberNotExists') == [None])
+
+    assert(r.geohash('Sicily', 'memberNotExists') == [None])
+
+    assert(r.geohash('Sicily') == [])
+
+
+def test_geopos():
+    r = getconn()
+
+    _geoadd_common(r)
+
+    assert(r.geopos('Sicily', 'Palermo', 'Catania') == [(13.361389338970184, 38.1155563954963),
+        (15.087267458438873, 37.50266842333162)])
+
+    assert(r.geopos('keyNotExists') == [])
+
+    assert(r.geopos('keyNotExists', 'memberNotExists') == [None])
+
+    assert(r.geopos('Sicily') == [])
+
+
+def test_georadius():
+    r = getconn()
+
+    _geoadd_common(r)
+
+    assert_fail('value is not a valid float', r.georadius, 'Sicily', 'invalidValue', 'invalidValue', 'invalidValue')
+
+    assert(r.georadius('keyNotExists', 15, 37, 200, 'km') == [])
+
+    assert(r.georadius('Sicily', 15, 37, 1, 'm') == [])
+
+    assert(r.georadius('Sicily', 15, 37, 200, 'km') == ['Palermo', 'Catania'])
+
+    assert(r.georadius('Sicily', 15, 37, 100000, 'm') == ['Catania'])
+
+    assert(r.georadius('Sicily', 15, 37, 200, 'km', withdist=True) == [
+        ['Palermo', 190.4424],
+        ['Catania', 56.4413]
+    ])
+
+    assert(r.georadius('Sicily', 15, 37, 200, 'km', withcoord=True) == [
+        ['Palermo', (13.361389338970184, 38.1155563954963)],
+        ['Catania', (15.087267458438873, 37.50266842333162)]
+    ])
+
+    assert(r.georadius('Sicily', 15, 37, 200, 'km', withhash=True) == [
+        ['Palermo', 3479099956230698],
+        ['Catania', 3479447370796909]
+    ])
+
+    assert(r.georadius('Sicily', 15, 37, 200, 'km', withdist=True, withcoord=True, withhash=True) == [
+        ['Palermo', 190.4424, 3479099956230698, (13.361389338970184, 38.1155563954963)],
+        ['Catania', 56.4413, 3479447370796909, (15.087267458438873, 37.50266842333162)]
+    ])
+
+    assert(r.georadius('Sicily', 15, 37, 200, 'km', count=1) == ['Catania'])
+
+    assert(r.georadius('Sicily', 15, 37, 200, 'km', count=1, sort='ASC') == ['Catania'])
+
+    assert(r.georadius('Sicily', 15, 37, 200, 'km', count=1, sort='DESC') == ['Palermo'])
+
+    assert(r.georadius('Sicily', 15, 37, 200, 'km', count=3, sort='ASC') == ['Catania', 'Palermo'])
+
+    assert(r.georadius('Sicily', 15, 37, 200, 'km', withdist=True, count=1) == [['Catania', 56.4413]])
+
+
+def test_georadiusbymember():
+    r = getconn()
+
+    r.geoadd('Sicily',
+        13.583333, 37.316667, 'Agrigento')
+    _geoadd_common(r)
+
+    assert(r.georadiusbymember('keyNotExists', 'memberNotExists', 200, 'km') == [])
+
+    assert_fail('could not decode requested zset member', r.georadiusbymember, 'Sicily', 'memberNotExists', 200, 'km')
+
+    assert(r.georadiusbymember('Sicily', 'Agrigento', 1, 'm') == ['Agrigento'])
+
+    assert(r.georadiusbymember('Sicily', 'Agrigento', 100, 'km') == ['Agrigento', 'Palermo'])
+
+    assert(r.georadiusbymember('Sicily', 'Agrigento', 100, 'km', withdist=True) == [
+        ['Agrigento', 0.0],
+        ['Palermo', 90.9778]
+    ])
+
+    assert(r.georadiusbymember('Sicily', 'Agrigento', 100, 'km', withcoord=True) == [
+        ['Agrigento', (13.583331406116486, 37.316668049938166)],
+        ['Palermo', (13.361389338970184, 38.1155563954963)]
+    ])
+
+    assert(r.georadiusbymember('Sicily', 'Agrigento', 100, 'km', withhash=True) == [
+        ['Agrigento', 3479030013248308],
+        ['Palermo', 3479099956230698]
+    ])
+
+    assert(r.georadiusbymember('Sicily', 'Agrigento', 100, 'km', withdist=True, withcoord=True, withhash=True) == [
+        ['Agrigento', 0.0, 3479030013248308, (13.583331406116486, 37.316668049938166)],
+        ['Palermo', 90.9778, 3479099956230698, (13.361389338970184, 38.1155563954963)]
+    ])
+
+    assert(r.georadiusbymember('Sicily', 'Agrigento', 100, 'km', count=1) == ['Agrigento'])
+
+    assert(r.georadiusbymember('Sicily', 'Agrigento', 100, 'km', count=1, sort='ASC') == ['Agrigento'])
+
+    assert(r.georadiusbymember('Sicily', 'Agrigento', 100, 'km', count=1, sort='DESC') == ['Palermo'])
+
+    assert(r.georadiusbymember('Sicily', 'Agrigento', 100, 'km', count=3, sort='ASC') == ['Agrigento', 'Palermo'])
+
+    assert(r.georadiusbymember('Sicily', 'Agrigento', 100, 'km', withdist=True, count=1) == [
+        ['Agrigento', 0.0]
+    ])
+


### PR DESCRIPTION
Problem

Currently does not support geo commands.

Solution

1. Enable to parse geo commands request.
2. Enable to parse nested multi bulk reply.

Result

1. Enable to execute geo commands such as `geoadd`, `geopos`, `geodist`, `geohash`, `georadius` and `georadiusbymember`.
2. Enable to parse nested multi bulk reply such as:

```
127.0.0.1:6379> GEOADD key 1 1 mem1 1.1 1.1 mem2
(integer) 2
127.0.0.1:6379> GEORADIUS key 1 1 1000 km WITHCOORD WITHDIST
1) 1) "mem1"
   2) "0.0001"
   3) 1) "0.99999994039535522"
      2) "0.99999945914297683"
2) 1) "mem2"
   2) "15.7282"
   3) 1) "1.09999805688858032"
      2) "1.09999927832122779"

```